### PR TITLE
Metadata update

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Package license: LGPL-2.1-or-later
 
 Summary: GROMACS is a versatile package to perform molecular dynamics.
 
-Development: https://github.com/gromacs/gromacs
+Development: https://gitlab.com/gromacs/gromacs
 
 Documentation: https://www.gromacs.org
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 # https://manual.gromacs.org/documentation/
 {% set name = "gromacs" %}
 {% set version = "2023.4" %}
-{% set build = 0 %}
+{% set build = 1 %}
 {% set build = build + 100 %}  # [mpi == 'nompi' and double == 'no' and cuda_compiler_version == "None"]
 
 package:
@@ -31,9 +31,9 @@ requirements:
     - make
     - {{ compiler('cxx') }}
     - {{ compiler('cuda') }}  # [cuda_compiler_version != "None"]
-    - cmake >3.13
+    - cmake >=3.18.4
     - pocl
-    - python >3.5
+    - python >=3.7
     - perl
     - libgomp  # [linux]
     - llvm-openmp  # [osx]
@@ -66,7 +66,7 @@ test:
 about:
   home: https://www.gromacs.org/
   license: LGPL-2.1-or-later
-  license_family: GPL
+  license_family: LGPL
   license_file: COPYING
   summary: GROMACS is a versatile package to perform molecular dynamics.
   description: |
@@ -78,8 +78,8 @@ about:
     at calculating the nonbonded interactions (that usually dominate
     simulations) many groups are also using it for research on
     non-biological systems, e.g. polymers.
-  doc_url: https://www.gromacs.org
-  dev_url: https://github.com/gromacs/gromacs
+  doc_url: https://manual.gromacs.org/
+  dev_url: https://gitlab.com/gromacs/gromacs
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
- Bump required versions of CMake and Python (same for both 2023 and 2024)
- Set licence_family to LGPL
- Set dev_url to GitLab (all the action happens there)
- Set doc_url specifically to the manual subdomain

Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.
