### PR TITLE
Fix the osx-arm64 build

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -164,7 +164,7 @@ esac
 function _gromacs_bin_dir() {
   local simdflavor
   local uname=\$(uname -m)
-  if [[ "\$uname" == "arm" ]]; then
+  if [[ "\$uname" == "arm*" ]]; then
     # Assume ARM Mac
     test -d "${PREFIX}/bin.ARM_NEON_ASIMD" && \
       simdflavor='ARM_NEON_ASIMD'
@@ -199,7 +199,7 @@ EOF
 #! /bin/tcsh
 
 setenv uname `uname -m`
-if ( `uname -m` == "arm64" && -d "${PREFIX}/bin.ARM_NEON_ASIMD" ) then ) then
+if ( `uname -m` == "arm*" && -d "${PREFIX}/bin.ARM_NEON_ASIMD" ) then ) then
    setenv simdflavor ARM_NEON_ASIMD
 else
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -220,7 +220,7 @@ else
     endif
 endif
 
-source "${PREFIX}/bin.\${simdflavor}/GMXRC"
+source "${PREFIX}/bin.\$simdflavor/GMXRC"
 
 EOF
 } > "${PREFIX}/etc/conda/activate.d/gromacs_activate.csh"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -220,7 +220,7 @@ else
     endif
 endif
 
-source "${PREFIX}/bin.${simdflavor}/GMXRC"
+source "${PREFIX}/bin.\${simdflavor}/GMXRC"
 
 EOF
 } > "${PREFIX}/etc/conda/activate.d/gromacs_activate.csh"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -164,7 +164,7 @@ esac
 function _gromacs_bin_dir() {
   local simdflavor
   local uname=\$(uname -m)
-  if [[ "\$uname" == "arm*" ]]; then
+  if [[ "\$uname" == "arm64" ]]; then
     # Assume ARM Mac
     test -d "${PREFIX}/bin.ARM_NEON_ASIMD" && \
       simdflavor='ARM_NEON_ASIMD'
@@ -199,7 +199,7 @@ EOF
 #! /bin/tcsh
 
 setenv uname `uname -m`
-if ( `uname -m` == "arm*" && -d "${PREFIX}/bin.ARM_NEON_ASIMD" ) then
+if ( `uname -m` == "arm64" && -d "${PREFIX}/bin.ARM_NEON_ASIMD" ) then
    setenv simdflavor ARM_NEON_ASIMD
 else
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -199,7 +199,7 @@ EOF
 #! /bin/tcsh
 
 setenv uname `uname -m`
-if ( `uname -m` == "arm*" && -d "${PREFIX}/bin.ARM_NEON_ASIMD" ) then ) then
+if ( `uname -m` == "arm*" && -d "${PREFIX}/bin.ARM_NEON_ASIMD" ) then
    setenv simdflavor ARM_NEON_ASIMD
 else
 
@@ -220,7 +220,7 @@ else
     endif
 endif
 
-source "${PREFIX}/bin.\$simdflavor/GMXRC"
+source "${PREFIX}/bin.${simdflavor}/GMXRC"
 
 EOF
 } > "${PREFIX}/etc/conda/activate.d/gromacs_activate.csh"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -199,7 +199,7 @@ EOF
 #! /bin/tcsh
 
 setenv uname `uname -m`
-if ( `uname -m` == "arm" && -d "${PREFIX}/bin.ARM_NEON_ASIMD" ) then ) then
+if ( `uname -m` == "arm64" && -d "${PREFIX}/bin.ARM_NEON_ASIMD" ) then ) then
    setenv simdflavor ARM_NEON_ASIMD
 else
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 # https://manual.gromacs.org/documentation/
 {% set name = "gromacs" %}
 {% set version = "2023.4" %}
-{% set build = 2 %}
+{% set build = 3 %}
 {% set build = build + 100 %}  # [mpi == 'nompi' and double == 'no' and cuda_compiler_version == "None"]
 
 package:


### PR DESCRIPTION
The arm64 mac has `$(uname -m)` as `arm64` not `arm`
Fix https://github.com/conda-forge/gromacs-feedstock/issues/44
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
